### PR TITLE
Mesos: Prevent requests from using chardet

### DIFF
--- a/checks.d/mesos.py
+++ b/checks.d/mesos.py
@@ -106,6 +106,9 @@ class Mesos(AgentCheck):
                 self.warning(msg)
                 return None
 
+        if r.encoding is None:
+            r.encoding = 'UTF8'
+
         return r.json()
 
     def timeout_event(self, url, timeout, aggregation_key):

--- a/checks.d/mesos_master.py
+++ b/checks.d/mesos_master.py
@@ -148,6 +148,9 @@ class MesosMaster(AgentCheck):
                                    message=msg)
                 raise CheckException("Cannot connect to mesos, please check your configuration.")
 
+        if r.encoding is None:
+            r.encoding = 'UTF8'
+
         return r.json()
 
     def _get_master_state(self, url, timeout):

--- a/checks.d/mesos_slave.py
+++ b/checks.d/mesos_slave.py
@@ -112,6 +112,9 @@ class MesosSlave(AgentCheck):
             if status is AgentCheck.CRITICAL:
                 raise CheckException("Cannot connect to mesos, please check your configuration.")
 
+        if r.encoding is None:
+            r.encoding = 'UTF8'
+
         return r.json()
 
     def _get_state(self, url, timeout):


### PR DESCRIPTION
This fixes DataDog/dd-agent#2191

Requests internally (and irritatingly imho) bundles `chardet`. It uses this library to figure out the encoding for a given response if there are no suitable HTTP headers detailing the character set of the response.

This library is pathologically slow (its loop heavy) on any python implementation _not_ running on top of a VM. There are better implementations of `chardet` for vanilla pythons but the requests library authors wish to avoid bundling C extensions. https://github.com/kennethreitz/requests/issues/2359

Taking a leaf from opentable, we now force the encoding of the mesos response to always be UTF8 which avoids requests pulling large mesos payloads through `chardet` and prevents the datadog agent taking large amounts of CPU time to run the check.